### PR TITLE
Feat/add monitoring base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,8 @@ RABBITMQ_PASS=guest
 
 # Application Configuration
 APP_PORT=6969
+
+# URL Configuration
+SEQ_URL=http://seq:5341
+ZIPKIN_URL=http://zipkin:9411/api/v2/spans
+ServiceName=search-api

--- a/dsl-compulsory1.sln
+++ b/dsl-compulsory1.sln
@@ -1,22 +1,51 @@
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.2.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "search-api", "src\search-api\search-api.csproj", "{0D9F4071-78D9-A2EB-7540-4CC51613A098}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonitoringService", "src\MonitoringService\MonitoringService.csproj", "{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|x64.Build.0 = Debug|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Debug|x86.Build.0 = Debug|Any CPU
 		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|x64.ActiveCfg = Release|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|x64.Build.0 = Release|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|x86.ActiveCfg = Release|Any CPU
+		{0D9F4071-78D9-A2EB-7540-4CC51613A098}.Release|x86.Build.0 = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|x64.Build.0 = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Debug|x86.Build.0 = Debug|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|x64.ActiveCfg = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|x64.Build.0 = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|x86.ActiveCfg = Release|Any CPU
+		{30728E39-CAB6-4F24-8C53-DEFD2C6F6A78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {02CF470A-04E2-48C2-A4B3-79F468B6052A}

--- a/src/MonitoringService/MonitoringService.csproj
+++ b/src/MonitoringService/MonitoringService.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="OpenTelemetry" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Exporter.Zipkin" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.2" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.1" />
+    <PackageReference Include="Serilog" Version="4.2.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="9.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="3.0.1" />
+    <PackageReference Include="Serilog.Enrichers.Process" Version="3.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Seq" Version="9.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/src/MonitoringService/Setup.cs
+++ b/src/MonitoringService/Setup.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using OpenTelemetry.Resources;
+using Serilog;
+
+using OpenTelemetry.Trace;
+
+namespace MonitoringService;
+
+public static class Setup
+{
+    public static void AddMonitoring(this IHostBuilder builder)
+    {
+        builder.UseSerilog((context, services, configuration) =>
+        {
+            configuration
+                .Enrich.FromLogContext()
+                .Enrich.WithEnvironmentName()
+                .Enrich.WithProcessId()
+                .Enrich.WithThreadId()
+                .WriteTo.Console()
+                .WriteTo.Seq(context.Configuration["SEQ_URL"] ?? "http://seq:5341")
+                .ReadFrom.Configuration(context.Configuration);
+        });
+    }
+
+    public static IServiceCollection AddTracing(this IServiceCollection services, IConfiguration configuration)
+    {
+        services.AddOpenTelemetry().WithTracing(tracerBuilder =>
+        {
+            tracerBuilder
+                .SetResourceBuilder(
+                    ResourceBuilder.CreateDefault()
+                        .AddService(configuration["ServiceName"] ?? "search-api"))
+                .AddAspNetCoreInstrumentation()
+                .AddHttpClientInstrumentation()
+                .AddZipkinExporter(options =>
+                {
+                    options.Endpoint = new Uri(configuration["ZIPKIN_URL"] ?? "http://zipkin:9411/api/v2/spans");
+                });
+        });
+
+        return services;
+    }
+}

--- a/src/search-api/Controllers/SearchController.cs
+++ b/src/search-api/Controllers/SearchController.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel.DataAnnotations;
-using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Searc.SearchApi.Models;
 using Searc.SearchApi.Services;

--- a/src/search-api/Program.cs
+++ b/src/search-api/Program.cs
@@ -1,6 +1,5 @@
-using System.Data;
 using dotenv.net;
-using Npgsql;
+using MonitoringService;
 using Scalar.AspNetCore;
 using Searc.SearchApi.Repositories;
 using Searc.SearchApi.Services;
@@ -14,11 +13,11 @@ DotEnv.Load(options: new DotEnvOptions(
 ));
 
 Console.WriteLine($"App Port: {Environment.GetEnvironmentVariable("APP_PORT")}");
-
 var builder = WebApplication.CreateBuilder(args);
 
 // Add environment variables to configuration
 builder.Configuration.AddEnvironmentVariables();
+
 // Add Postgres configuration
 var connectionString = $"Host={Environment.GetEnvironmentVariable("DB_HOST")};Port={Environment.GetEnvironmentVariable("DB_PORT")};Database={Environment.GetEnvironmentVariable("DB_NAME")};Username={Environment.GetEnvironmentVariable("DB_USER")};Password={Environment.GetEnvironmentVariable("DB_PASSWORD")}";
 builder.Services.AddNpgsqlDataSource(connectionString);
@@ -34,13 +33,16 @@ builder.Services.AddCors(options =>
     });
 });
 
+// Add monitoring and tracing
+builder.Host.AddMonitoring();
+builder.Services.AddTracing(builder.Configuration);
+
 // Add services to the container.
 builder.Services.AddSingleton<ISearchService, SearchService>();
 builder.Services.AddSingleton<ISearchRepository, SearchRepository>();
-// Add controllers to the container.
+
 builder.Services.AddControllers();
-// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
-builder.Services.AddOpenApi();
+builder.Services.AddOpenApi(); // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 
 var app = builder.Build();
 
@@ -53,9 +55,6 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
-
 app.UseAuthorization();
-
 app.MapControllers();
-
 app.Run();

--- a/src/search-api/repositories/SearchRepository.cs
+++ b/src/search-api/repositories/SearchRepository.cs
@@ -1,4 +1,3 @@
-using System.Data;
 using System.Data.Common;
 using Searc.SearchApi.Models;
 using Dapper;

--- a/src/search-api/search-api.csproj
+++ b/src/search-api/search-api.csproj
@@ -14,4 +14,8 @@
     <PackageReference Include="Scalar.AspNetCore" Version="2.0.22" />
   </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\MonitoringService\MonitoringService.csproj" />
+  </ItemGroup>
+
 </Project>

--- a/src/search-api/services/SearchService.cs
+++ b/src/search-api/services/SearchService.cs
@@ -1,4 +1,3 @@
-using System.Threading.Tasks;
 using Searc.SearchApi.Models;
 using Searc.SearchApi.Repositories;
 


### PR DESCRIPTION
This pull request includes several changes to add a new monitoring service and improve the existing search API project. The key changes involve adding monitoring and tracing capabilities, updating project configurations, and including necessary dependencies.

### Monitoring and Tracing Integration:
* Added a new project `MonitoringService` with necessary dependencies and setup for OpenTelemetry and Serilog. (`src/MonitoringService/MonitoringService.csproj`, `src/MonitoringService/Setup.cs`) [[1]](diffhunk://#diff-9690a3939e87874b74cc7645056252e4008bfe7b1b143a7290643765cb008046R1-R24) [[2]](diffhunk://#diff-e706278ce1b08fb08b299d66649d4d59593f24de871ab9e41c2abc837969c1b7R1-R46)
* Integrated monitoring and tracing in the `Program.cs` file of the `search-api` project. (`src/search-api/Program.cs`) [[1]](diffhunk://#diff-cdf0ef1327c2b7af937612b8552d55c864eeeb7a8905c80f34cf58c21c00e9f2L1-R2) [[2]](diffhunk://#diff-cdf0ef1327c2b7af937612b8552d55c864eeeb7a8905c80f34cf58c21c00e9f2L17-R20) [[3]](diffhunk://#diff-cdf0ef1327c2b7af937612b8552d55c864eeeb7a8905c80f34cf58c21c00e9f2R36-R45)

### Project Configuration:
* Updated the solution file to include the new `MonitoringService` project and added build configurations for different CPU architectures. (`dsl-compulsory1.sln`)
* Added project reference to `MonitoringService` in the `search-api` project file. (`src/search-api/search-api.csproj`)

### Environment Configuration:
* Added environment variable configurations for SEQ and ZIPKIN URLs in the `.env.example` file. (`.env.example`)

### Code Cleanup:
* Removed unused `using` directives in several files within the `search-api` project. (`src/search-api/Controllers/SearchController.cs`, `src/search-api/Program.cs`, `src/search-api/repositories/SearchRepository.cs`, `src/search-api/services/SearchService.cs`) [[1]](diffhunk://#diff-7c5499c3d4afb43551d7fb6d8ea978ebdc6503ae090cce9e1c8effa55e5ca52aL2) [[2]](diffhunk://#diff-669eaef83091c80822632192592467483a5aed2a26f19c4a8b480a2926b9bc34L1) [[3]](diffhunk://#diff-98b3270eea547eaa63fe143d180ee9ffc7825134dc206a2e01947f1218b123e9L1)